### PR TITLE
Refine example files structure

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,11 +17,6 @@
         @onEndReached="handleEndReached"
       >
       </virtualised-list>
-      <!-- <virtualised-list :nodes="[1, 2, 3, 4, 5]">
-        <template #cell="slotProps">
-          {{ slotProps.node }}
-        </template>
-      </virtualised-list> -->
     </div>
     <div class="tree-container">
       <div class="title">VirtualisedTree</div>
@@ -44,28 +39,6 @@
       >
         <template #fallback><div>Loading tree...</div></template>
       </virtualised-tree>
-      <!-- <virtualised-tree
-        :nodes="[
-          {
-            name: 'Node 1',
-            children: [{ name: 'Leaf 1' }],
-            state: { expanded: true },
-          },
-          { name: 'Node 2' },
-        ]"
-      >
-        <template #cell="slotProps">
-          node.parents is an array that contains all parent nodes' index
-          <div
-            :style="{
-              textAlign: 'left',
-              marginLeft: `${slotProps.node.parents.length * 30}px`,
-            }"
-          >
-            {{ slotProps.node.name }}
-          </div>
-        </template>
-      </virtualised-tree> -->
     </div>
   </div>
 </template>

--- a/src/examples/demo-example/DemoExample.vue
+++ b/src/examples/demo-example/DemoExample.vue
@@ -45,13 +45,13 @@
 
 <script>
 import { ref, h } from "vue";
-import VirtualisedList from "./components/VirtualisedList";
-import VirtualisedTree from "./components/VirtualisedTree";
+import VirtualisedList from "../../components/VirtualisedList";
+import VirtualisedTree from "../../components/VirtualisedTree";
 
-import { constructFixedTree } from "./utils/mock";
+import { constructFixedTree } from "../../utils/mock";
 
 export default {
-  name: "App",
+  name: "DemoExample",
   components: {
     VirtualisedTree,
     VirtualisedList,

--- a/src/examples/simple-example/SimpleExample.vue
+++ b/src/examples/simple-example/SimpleExample.vue
@@ -1,0 +1,78 @@
+<template>
+  <label for="components">Select a Component</label>
+  <select
+    ref="componentSelector"
+    name="components"
+    @input="onSelectedComponentChange"
+  >
+    <option
+      v-for="(component, index) in components"
+      :key="index"
+      :value="component"
+    >
+      {{ component }}
+    </option>
+  </select>
+  <virtualised-list
+    v-if="selectedComponent === 'VirtualisedList'"
+    :nodes="[1, 2, 3, 4, 5]"
+  >
+    <template #cell="slotProps">
+      {{ slotProps.node }}
+    </template>
+  </virtualised-list>
+  <virtualised-tree
+    v-if="selectedComponent === 'VirtualisedTree'"
+    :nodes="[
+      {
+        name: 'Node 1',
+        children: [{ name: 'Leaf 1' }],
+        state: { expanded: true },
+      },
+      { name: 'Node 2' },
+    ]"
+  >
+    <template #cell="slotProps">
+      <!-- node.parents is an array that contains all parent nodes' index -->
+      <div
+        :style="{
+          textAlign: 'left',
+          marginLeft: `${slotProps.node.parents.length * 30}px`,
+        }"
+      >
+        {{ slotProps.node.name }}
+      </div>
+    </template>
+  </virtualised-tree>
+</template>
+
+<script>
+import { ref, onMounted } from "vue";
+import VirtualisedList from "../../components/VirtualisedList";
+import VirtualisedTree from "../../components/VirtualisedTree";
+
+export default {
+  name: "SimpleExample",
+  components: { VirtualisedList, VirtualisedTree },
+  setup() {
+    const componentSelector = ref(null);
+    const components = ref(["VirtualisedList", "VirtualisedTree"]);
+    const selectedComponent = ref(null);
+
+    const onSelectedComponentChange = () => {
+      selectedComponent.value = componentSelector.value.value;
+    };
+
+    onMounted(() => (selectedComponent.value = componentSelector.value.value));
+
+    return {
+      componentSelector,
+      components,
+      selectedComponent,
+      onSelectedComponentChange,
+    };
+  },
+};
+</script>
+
+<style></style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
 import { createApp } from "vue";
-import App from "./App.vue";
+import SimpleExample from "./examples/simple-example/SimpleExample.vue";
 
-createApp(App).mount("#app");
+createApp(SimpleExample).mount("#app");

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,6 @@
 import { createApp } from "vue";
-import SimpleExample from "./examples/simple-example/SimpleExample.vue";
+// import SimpleExample from "./examples/simple-example/SimpleExample.vue";
+import DemoExample from "./examples/demo-example/DemoExample.vue";
 
-createApp(SimpleExample).mount("#app");
+// createApp(SimpleExample).mount("#app");
+createApp(DemoExample).mount("#app");


### PR DESCRIPTION
To make the `src` folder clearer, we removed `App.vue` and created an `examples` folder with various examples.