### PR TITLE
Set inline CSS and update document

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,8 @@
 .vscode
 public
+examples
 .editorconfig
 babel.config.js
+.eslintrc.js
 *.gif
 *.log

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/vue-virtualised.svg)](https://www.npmjs.com/package/vue-virtualised)
 [![license](https://img.shields.io/npm/l/vue-virtualised.svg?style=flat)](LICENSE)
+[![vue3](https://img.shields.io/badge/vue-3.x-brightgreen.svg)](https://v3.vuejs.org/)
 
 > Vue components developed by [Vue.js 3.0](https://v3.vuejs.org/) for efficiently rendering large scrollable lists and hierarchical data. `vue-virtualised` is able to render and update 1 million nodes within a few seconds in front-end.
 
@@ -28,12 +29,6 @@ import { VirtualisedList, VirtualisedTree } from "vue-virtualised";
 
 // Or you can import the component as a named export. e.g.
 import { VirtualisedTree as Tree } from "vue-virtualised";
-```
-
-⚠️ The line below should be included when importing the package:
-
-```js
-import "vue-virtualised/dist/vue-virtualised.css";
 ```
 
 ## Usage

--- a/src/components/Base/VirtualisedBaseScroller.vue
+++ b/src/components/Base/VirtualisedBaseScroller.vue
@@ -1,15 +1,15 @@
 <template>
   <div
     ref="virtualScroller"
-    class="virtual-scroller-container"
-    :style="{ height: `${viewportHeight}px` }"
+    :style="{ height: `${viewportHeight}px`, overflow: 'auto' }"
     @scroll.passive="handleScroll"
   >
     <div
-      class="virtual-scroller-content"
       :style="{
         height: `${totalHeight}px`,
         willChange: 'transform',
+        position: 'relative',
+        overflow: 'hidden',
       }"
     >
       <div
@@ -410,12 +410,4 @@ export default defineComponent({
 });
 </script>
 
-<style>
-.virtual-scroller-container {
-  overflow: auto;
-}
-.virtual-scroller-content {
-  overflow: hidden;
-  position: relative;
-}
-</style>
+<style></style>


### PR DESCRIPTION
It's risky that we required users to import `*.css` file manually - users might overwrite the style, which is probably causing the scroller to display incorrectly.
This PR moves styles in `VirtualisedBaseScroller` component in the template. As a result, the user doesn't have to import stylesheet anymore.
In addition, the document is also updated.